### PR TITLE
Added support for multi-dimensional arrays in POST params

### DIFF
--- a/CurlWrapper.php
+++ b/CurlWrapper.php
@@ -547,7 +547,7 @@ class CurlWrapper
             if (isset($this->options[CURLOPT_HTTPGET])) {
                 $this->prepareGetParams();
             } else {
-                $this->addOption(CURLOPT_POSTFIELDS, $this->requestParams);
+                $this->addOption(CURLOPT_POSTFIELDS, http_build_query($this->requestParams));
             }
         }
 


### PR DESCRIPTION
Multi-dimensional arrays were not being passed correctly as parameters
in POST requests. Wrapping $this->requestParams in http_build_query()
fixes this.
